### PR TITLE
feat(barrel): support globbing and customised exports

### DIFF
--- a/packages/eslint-plugin-codegen/readme.md
+++ b/packages/eslint-plugin-codegen/readme.md
@@ -112,7 +112,7 @@ See below for documentation. This repo also has [lots of usage examples](https:/
 ### Presets
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: monorepoTOC} -->
-#### [monorepoTOC](./src/presets.ts#L294)
+#### [monorepoTOC](./src/presets.ts#L284)
 
 Generate a table of contents for a monorepo.
 
@@ -139,14 +139,17 @@ Generate a table of contents for a monorepo.
 ![](./gifs/monorepoTOC.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: barrel} -->
-#### [barrel](./src/presets.ts#L39)
+#### [barrel](./src/presets.ts#L29)
 
 Bundle several modules into a single convenient one.
 
 ##### Example
 
-```
-// codegen:start {preset: barrel, include: some/path/*.ts, exclude: some/path/*util.ts} export * from './some/path/module-a' export * from './some/path/module-b' export * from './some/path/module-c'
+```typescript
+// codegen:start {preset: barrel, include: some/path/*.ts, exclude: some/path/*util.ts}
+export * from './some/path/module-a'
+export * from './some/path/module-b'
+export * from './some/path/module-c'
 // codegen:end
 ```
 
@@ -154,17 +157,10 @@ Bundle several modules into a single convenient one.
 
 |name|description|
 |-|-|
-|glob|[optional]
-If specified, the barrel will only include file paths that match this glob pattern|
-|exclude|[optional]
-If specified, the barrel will exclude file paths that match these glob patterns|
-|import|[optional]
-If specified, matching files will be imported and re-exported rather than directly exported with
-`export * from './xyz'`. Set to `default` to use default import instead of `import * as`.|
-|export|[optional]
-If specified, matching modules will be bundled into a const or default export based on this name.
-If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise
-the file paths will be camel-cased to make them valid js identifiers.|
+|glob|[optional] If specified, the barrel will only include file paths that match this glob pattern|
+|exclude|[optional] If specified, the barrel will exclude file paths that match these glob patterns|
+|import|[optional] If specified, matching files will be imported and re-exported rather than directly exported with `export * from './xyz'`. Use `import: star` for `import * as xyz from './xyz'` style imports. Use `import: default` for `import xyz from './xyz'` style imports.|
+|export|[optional] Only valid if the import style has been specified (either `import: star` or `import: default`). If specified, matching modules will be bundled into a const or default export based on this name. If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise the file paths will be camel-cased to make them valid js identifiers.|
 <!-- codegen:end -->
 
 ##### Demo
@@ -172,7 +168,7 @@ the file paths will be camel-cased to make them valid js identifiers.|
 ![](./gifs/barrel.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: markdownFromJsdoc} -->
-#### [markdownFromJsdoc](./src/presets.ts#L115)
+#### [markdownFromJsdoc](./src/presets.ts#L105)
 
 Convert jsdoc for an es export from a javascript/typescript file to markdown.
 
@@ -193,7 +189,7 @@ Convert jsdoc for an es export from a javascript/typescript file to markdown.
 ![](./gifs/markdownFromJsdoc.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: markdownTOC} -->
-#### [markdownTOC](./src/presets.ts#L193)
+#### [markdownTOC](./src/presets.ts#L183)
 
 Generate a table of contents from the current markdown file, based on markdown headers (e.g. `### My section title`)
 
@@ -214,7 +210,7 @@ Generate a table of contents from the current markdown file, based on markdown h
 ![](./gifs/markdownTOC.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: markdownFromTests} -->
-#### [markdownFromTests](./src/presets.ts#L238)
+#### [markdownFromTests](./src/presets.ts#L228)
 
 Use a test file to generate library usage documentation. Note: this has been tested with jest. It _might_ also work fine with mocha, and maybe ava, but those haven't been tested.
 
@@ -235,7 +231,7 @@ Use a test file to generate library usage documentation. Note: this has been tes
 ![](./gifs/markdownFromTests.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: custom} -->
-#### [custom](./src/presets.ts#L385)
+#### [custom](./src/presets.ts#L375)
 
 Define your own codegen function, which will receive all options specified. Import the `Preset` type from this library to define a strongly-typed preset function:
 

--- a/packages/eslint-plugin-codegen/readme.md
+++ b/packages/eslint-plugin-codegen/readme.md
@@ -157,7 +157,7 @@ export * from './some/path/module-c'
 
 |name|description|
 |-|-|
-|glob|[optional] If specified, the barrel will only include file paths that match this glob pattern|
+|include|[optional] If specified, the barrel will only include file paths that match this glob pattern|
 |exclude|[optional] If specified, the barrel will exclude file paths that match these glob patterns|
 |import|[optional] If specified, matching files will be imported and re-exported rather than directly exported with `export * from './xyz'`. Use `import: star` for `import * as xyz from './xyz'` style imports. Use `import: default` for `import xyz from './xyz'` style imports.|
 |export|[optional] Only valid if the import style has been specified (either `import: star` or `import: default`). If specified, matching modules will be bundled into a const or default export based on this name. If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise the file paths will be camel-cased to make them valid js identifiers.|

--- a/packages/eslint-plugin-codegen/readme.md
+++ b/packages/eslint-plugin-codegen/readme.md
@@ -112,7 +112,7 @@ See below for documentation. This repo also has [lots of usage examples](https:/
 ### Presets
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: monorepoTOC} -->
-#### [monorepoTOC](./src/presets.ts#L235)
+#### [monorepoTOC](./src/presets.ts#L294)
 
 Generate a table of contents for a monorepo.
 
@@ -139,20 +139,32 @@ Generate a table of contents for a monorepo.
 ![](./gifs/monorepoTOC.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: barrel} -->
-#### [barrel](./src/presets.ts#L23)
+#### [barrel](./src/presets.ts#L39)
 
-Rollup exports from several modules into a single convenient module, typically named `index.ts`
+Bundle several modules into a single convenient one.
 
 ##### Example
 
-`// codegen:start {preset: barrel, include: foo, exclude: bar}`
+```
+// codegen:start {preset: barrel, include: some/path/*.ts, exclude: some/path/*util.ts} export * from './some/path/module-a' export * from './some/path/module-b' export * from './some/path/module-c'
+// codegen:end
+```
 
 ##### Params
 
 |name|description|
 |-|-|
-|include|[optional] If specified, the barrel will only include filenames that match this regex|
-|exclude|[optional] If specified, the barrel will only include filenames that don't match this regex|
+|glob|[optional]
+If specified, the barrel will only include file paths that match this glob pattern|
+|exclude|[optional]
+If specified, the barrel will exclude file paths that match these glob patterns|
+|import|[optional]
+If specified, matching files will be imported and re-exported rather than directly exported with
+`export * from './xyz'`. Set to `default` to use default import instead of `import * as`.|
+|export|[optional]
+If specified, matching modules will be bundled into a const or default export based on this name.
+If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise
+the file paths will be camel-cased to make them valid js identifiers.|
 <!-- codegen:end -->
 
 ##### Demo
@@ -160,7 +172,7 @@ Rollup exports from several modules into a single convenient module, typically n
 ![](./gifs/barrel.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: markdownFromJsdoc} -->
-#### [markdownFromJsdoc](./src/presets.ts#L56)
+#### [markdownFromJsdoc](./src/presets.ts#L115)
 
 Convert jsdoc for an es export from a javascript/typescript file to markdown.
 
@@ -181,7 +193,7 @@ Convert jsdoc for an es export from a javascript/typescript file to markdown.
 ![](./gifs/markdownFromJsdoc.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: markdownTOC} -->
-#### [markdownTOC](./src/presets.ts#L134)
+#### [markdownTOC](./src/presets.ts#L193)
 
 Generate a table of contents from the current markdown file, based on markdown headers (e.g. `### My section title`)
 
@@ -202,7 +214,7 @@ Generate a table of contents from the current markdown file, based on markdown h
 ![](./gifs/markdownTOC.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: markdownFromTests} -->
-#### [markdownFromTests](./src/presets.ts#L179)
+#### [markdownFromTests](./src/presets.ts#L238)
 
 Use a test file to generate library usage documentation. Note: this has been tested with jest. It _might_ also work fine with mocha, and maybe ava, but those haven't been tested.
 
@@ -223,7 +235,7 @@ Use a test file to generate library usage documentation. Note: this has been tes
 ![](./gifs/markdownFromTests.gif)
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/presets.ts, export: custom} -->
-#### [custom](./src/presets.ts#L326)
+#### [custom](./src/presets.ts#L385)
 
 Define your own codegen function, which will receive all options specified. Import the `Preset` type from this library to define a strongly-typed preset function:
 

--- a/packages/eslint-plugin-codegen/src/__tests__/presets.test.ts
+++ b/packages/eslint-plugin-codegen/src/__tests__/presets.test.ts
@@ -392,7 +392,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}*'},
+        options: {include: '{a,b}*'},
       })
     ).toMatchInlineSnapshot(`
       "export * from './a'
@@ -411,7 +411,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}*', exclude: ['*util*']},
+        options: {include: '{a,b}*', exclude: ['*util*']},
       })
     ).toMatchInlineSnapshot(`
       "export * from './a'
@@ -421,7 +421,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'star'},
+        options: {include: '{a,b}.ts', import: 'star'},
       })
     ).toMatchInlineSnapshot(`
       "import * as a from './a'
@@ -437,7 +437,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'default'},
+        options: {include: '{a,b}.ts', import: 'default'},
       })
     ).toMatchInlineSnapshot(`
       "import a from './a'
@@ -453,7 +453,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'star', export: 'default'},
+        options: {include: '{a,b}.ts', import: 'star', export: 'default'},
       })
     ).toMatchInlineSnapshot(`
       "import * as a from './a'
@@ -469,7 +469,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'star', export: 'foo'},
+        options: {include: '{a,b}.ts', import: 'star', export: 'foo'},
       })
     ).toMatchInlineSnapshot(`
       "import * as a from './a'
@@ -485,7 +485,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'star', export: {name: 'foo', keys: 'path'}},
+        options: {include: '{a,b}.ts', import: 'star', export: {name: 'foo', keys: 'path'}},
       })
     ).toMatchInlineSnapshot(`
       "import * as a from './a'
@@ -501,7 +501,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'star', export: {name: 'foo', keys: 'camelCase'}},
+        options: {include: '{a,b}.ts', import: 'star', export: {name: 'foo', keys: 'camelCase'}},
       })
     ).toMatchInlineSnapshot(`
       "import * as a from './a'
@@ -517,7 +517,7 @@ describe('barrel', () => {
     expect(
       presets.barrel({
         meta: {filename: 'index.ts', existingContent: ''},
-        options: {glob: '{a,b}.ts', import: 'star', export: {name: 'default', keys: 'path'}},
+        options: {include: '{a,b}.ts', import: 'star', export: {name: 'default', keys: 'path'}},
       })
     ).toMatchInlineSnapshot(`
       "import * as a from './a'

--- a/packages/eslint-plugin-codegen/src/__tests__/rule.test.ts
+++ b/packages/eslint-plugin-codegen/src/__tests__/rule.test.ts
@@ -3,18 +3,9 @@ import * as codegen from '..'
 import baseDedent from 'dedent'
 import * as os from 'os'
 
-jest.mock('fs', () => {
-  const realFs: typeof import('fs') = jest.requireActual('fs')
-  return {
-    ...realFs,
-    readdirSync: (path: string) => {
-      if (path.endsWith('__tests__')) {
-        return ['foo.ts', 'bar.ts']
-      }
-      return realFs.readdirSync(path)
-    },
-  }
-})
+jest.mock('glob', () => ({
+  sync: () => ['foo.ts', 'bar.ts'],
+}))
 
 /** wrapper for dedent which respects os.EOL */
 const dedent = (...args: Parameters<typeof baseDedent>) => {

--- a/packages/eslint-plugin-codegen/src/presets.ts
+++ b/packages/eslint-plugin-codegen/src/presets.ts
@@ -14,27 +14,17 @@ export type Preset<Options> = (params: {meta: {filename: string; existingContent
 /**
  * Bundle several modules into a single convenient one.
  *
- * ##### Example
- *
- * ```
+ * @example
  * // codegen:start {preset: barrel, include: some/path/*.ts, exclude: some/path/*util.ts}
  * export * from './some/path/module-a'
  * export * from './some/path/module-b'
  * export * from './some/path/module-c'
  * // codegen:end
- * ```
  *
- * @param glob [optional]
- * If specified, the barrel will only include file paths that match this glob pattern
- * @param exclude [optional]
- * If specified, the barrel will exclude file paths that match these glob patterns
- * @param import [optional]
- * If specified, matching files will be imported and re-exported rather than directly exported with
- * `export * from './xyz'`. Set to `default` to use default import instead of `import * as`.
- * @param export [optional]
- * If specified, matching modules will be bundled into a const or default export based on this name.
- * If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise
- * the file paths will be camel-cased to make them valid js identifiers.
+ * @param glob [optional] If specified, the barrel will only include file paths that match this glob pattern
+ * @param exclude [optional] If specified, the barrel will exclude file paths that match these glob patterns
+ * @param import [optional] If specified, matching files will be imported and re-exported rather than directly exported with `export * from './xyz'`. Use `import: star` for `import * as xyz from './xyz'` style imports. Use `import: default` for `import xyz from './xyz'` style imports.
+ * @param export [optional] Only valid if the import style has been specified (either `import: star` or `import: default`). If specified, matching modules will be bundled into a const or default export based on this name. If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise the file paths will be camel-cased to make them valid js identifiers.
  */
 export const barrel: Preset<{
   glob?: string

--- a/packages/eslint-plugin-codegen/src/presets.ts
+++ b/packages/eslint-plugin-codegen/src/presets.ts
@@ -21,13 +21,13 @@ export type Preset<Options> = (params: {meta: {filename: string; existingContent
  * export * from './some/path/module-c'
  * // codegen:end
  *
- * @param glob [optional] If specified, the barrel will only include file paths that match this glob pattern
+ * @param include [optional] If specified, the barrel will only include file paths that match this glob pattern
  * @param exclude [optional] If specified, the barrel will exclude file paths that match these glob patterns
  * @param import [optional] If specified, matching files will be imported and re-exported rather than directly exported with `export * from './xyz'`. Use `import: star` for `import * as xyz from './xyz'` style imports. Use `import: default` for `import xyz from './xyz'` style imports.
  * @param export [optional] Only valid if the import style has been specified (either `import: star` or `import: default`). If specified, matching modules will be bundled into a const or default export based on this name. If set to `{name: someName, keys: path}` the relative file paths will be used as keys. Otherwise the file paths will be camel-cased to make them valid js identifiers.
  */
 export const barrel: Preset<{
-  glob?: string
+  include?: string
   exclude?: string | string[]
   import?: 'default' | 'star'
   export?: string | {name: string; keys: 'path' | 'camelCase'}
@@ -35,7 +35,7 @@ export const barrel: Preset<{
   const cwd = path.dirname(meta.filename)
 
   const ext = meta.filename.split('.').slice(-1)[0]
-  const pattern = opts.glob || `*.${ext}`
+  const pattern = opts.include || `*.${ext}`
 
   const relativeFiles = glob
     .sync(pattern, {cwd, ignore: opts.exclude})


### PR DESCRIPTION
This change is breaking - previously, regexes were used for including and excluding files. This switches to glob patterns.