### PR TITLE
fix: trim empty lines

### DIFF
--- a/common/changes/eslint-plugin-codegen/codegen-trim-empty-lines_pr-201.json
+++ b/common/changes/eslint-plugin-codegen/codegen-trim-empty-lines_pr-201.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: trim empty lines (#201)",
+      "type": "patch",
+      "packageName": "eslint-plugin-codegen"
+    }
+  ],
+  "packageName": "eslint-plugin-codegen",
+  "email": "mmkal@users.noreply.github.com"
+}

--- a/packages/eslint-plugin-codegen/src/__tests__/plugin.test.ts
+++ b/packages/eslint-plugin-codegen/src/__tests__/plugin.test.ts
@@ -24,11 +24,11 @@ describe('markdown processor', () => {
       Array [
         "/* eslint-disable prettier/prettier */ // eslint-plugin-codegen:remove
       // eslint-plugin-codegen:trim# Title
-      // eslint-plugin-codegen:trim
+
       // eslint-plugin-codegen:trim<!-- comment -->
-      // eslint-plugin-codegen:trim
+
       // eslint-plugin-codegen:trim<div>html</div>
-      // eslint-plugin-codegen:trim
+
       // eslint-plugin-codegen:trim\`\`\`js
       // eslint-plugin-codegen:trim// some javascript
       // eslint-plugin-codegen:trimconst x = 1

--- a/packages/eslint-plugin-codegen/src/index.ts
+++ b/packages/eslint-plugin-codegen/src/index.ts
@@ -21,7 +21,7 @@ const getPreprocessor = (): eslint.Linter.LintOptions => {
         os.EOL +
         text
           .split(/\r?\n/)
-          .map(line => `// eslint-plugin-codegen:trim${line}`)
+          .map(line => line && `// eslint-plugin-codegen:trim${line}`)
           .join(os.EOL),
     ],
     postprocess: messageLists => ([] as eslint.Linter.LintMessage[]).concat(...messageLists),
@@ -109,7 +109,7 @@ const codegen: eslint.Rule.RuleModule = {
         const opts = maybeOptions.right || {}
         const presets: Record<string, presetsModule.Preset<unknown> | undefined> = {
           ...presetsModule,
-          ...context.options?.[0]?.presets,
+          ...context.options[0]?.presets,
         }
         const preset = typeof opts?.preset === 'string' && presets[opts.preset]
         if (typeof preset !== 'function') {


### PR DESCRIPTION
this prevents an interaction with other lint rules which expect newlines at the end of the file

<!-- Every pull request which changes one of the packages in this monorepo needs to be accompanied by a rush changefile. The change text needs to consist of the PR title and number. There's a CI job that checks this for you, and prints a runnable command for generating the file. After you open the PR, watch out for the "create change files" workflow - that will have instructions for creating the changefile. -->
