### PR TITLE
fix: test explicitly for `never` in `Extends`

### DIFF
--- a/common/changes/expect-type/negative-never-tests_pr-216.json
+++ b/common/changes/expect-type/negative-never-tests_pr-216.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: test explicitly for `never` in `Extends` (#216)",
+      "type": "patch",
+      "packageName": "expect-type"
+    }
+  ],
+  "packageName": "expect-type",
+  "email": "mmkal@users.noreply.github.com"
+}

--- a/packages/expect-type/readme.md
+++ b/packages/expect-type/readme.md
@@ -128,6 +128,9 @@ Catch any/unknown/never types:
 expectTypeOf<unknown>().toBeUnknown()
 expectTypeOf<any>().toBeAny()
 expectTypeOf<never>().toBeNever()
+
+// @ts-expect-error
+expectTypeOf<never>().toBeNumber()
 ```
 
 `.toEqualTypeOf` distinguishes between deeply-nested `any` and `unknown` properties:

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -52,6 +52,9 @@ test('Catch any/unknown/never types', () => {
   expectTypeOf<unknown>().toBeUnknown()
   expectTypeOf<any>().toBeAny()
   expectTypeOf<never>().toBeNever()
+
+  // @ts-expect-error
+  expectTypeOf<never>().toBeNumber()
 })
 
 test('`.toEqualTypeOf` distinguishes between deeply-nested `any` and `unknown` properties', () => {

--- a/packages/expect-type/src/__tests__/types.test.ts
+++ b/packages/expect-type/src/__tests__/types.test.ts
@@ -48,6 +48,26 @@ test('boolean type logic', () => {
   expectTypeOf<a.Equal<never, unknown>>().toEqualTypeOf<false>()
 })
 
+test(`never types don't sneak by`, () => {
+  // @ts-expect-error
+  expectTypeOf<never>().toBeNumber()
+
+  // @ts-expect-error
+  expectTypeOf<never>().toBeString()
+
+  // @ts-expect-error
+  expectTypeOf<never>().toBeAny()
+
+  // @ts-expect-error
+  expectTypeOf<never>().toBeUnknown()
+
+  // @ts-expect-error
+  expectTypeOf<never>().toEqualTypeOf<{foo: string}>()
+
+  // @ts-expect-error
+  expectTypeOf<never>().toMatchTypeOf<{foo: string}>()
+})
+
 test('constructor params', () => {
   // The built-in ConstructorParameters type helper fails to pick up no-argument overloads.
   // This test checks that's still the case to avoid unnecessarily maintaining a workaround,

--- a/packages/expect-type/src/index.ts
+++ b/packages/expect-type/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 export type Not<T extends boolean> = T extends true ? false : true
 export type Or<Types extends boolean[]> = Types[number] extends false ? false : true
 export type And<Types extends boolean[]> = Types[number] extends true ? true : false
@@ -62,7 +61,7 @@ type ReadonlyEquivalent<X, Y> = Extends<
   (<T>() => T extends Y ? true : false)
 >
 
-export type Extends<L, R> = L extends R ? true : false
+export type Extends<L, R> = IsNever<L> extends true ? IsNever<R> : L extends R ? true : false
 export type StrictExtends<L, R> = Extends<DeepBrand<L>, DeepBrand<R>>
 
 export type Equal<Left, Right> = And<[StrictExtends<Left, Right>, StrictExtends<Right, Left>]>


### PR DESCRIPTION
<!-- Every pull request which changes one of the packages in this monorepo needs to be accompanied by a rush changefile. The change text needs to consist of the PR title and number. There's a CI job that checks this for you, and prints a runnable command for generating the file. After you open the PR, watch out for the "create change files" workflow - that will have instructions for creating the changefile. -->
