### PR TITLE
toBeVoid() added to expect-type

### DIFF
--- a/common/changes/expect-type/expect-type-void_pr-221.json
+++ b/common/changes/expect-type/expect-type-void_pr-221.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "toBeVoid() added to expect-type (#221) - @rraziel",
+      "type": "minor",
+      "packageName": "expect-type"
+    }
+  ],
+  "packageName": "expect-type",
+  "email": "rraziel@users.noreply.github.com"
+}

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import {expectTypeOf} from '..'
 
 test("Check an object's type with `.toEqualTypeOf`", () => {

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -69,6 +69,7 @@ test('Test for basic javascript types', () => {
   expectTypeOf('').toBeString()
   expectTypeOf(1).toBeNumber()
   expectTypeOf(true).toBeBoolean()
+  expectTypeOf(() => {}).returns.toBeVoid()
   expectTypeOf(Promise.resolve(123)).resolves.toBeNumber()
   expectTypeOf(Symbol(1)).toBeSymbol()
 })

--- a/packages/expect-type/src/index.ts
+++ b/packages/expect-type/src/index.ts
@@ -85,6 +85,7 @@ export interface ExpectTypeOf<Actual, B extends boolean> {
   toBeNumber: (...MISMATCH: MismatchArgs<Extends<Actual, number>, B>) => true
   toBeString: (...MISMATCH: MismatchArgs<Extends<Actual, string>, B>) => true
   toBeBoolean: (...MISMATCH: MismatchArgs<Extends<Actual, boolean>, B>) => true
+  toBeVoid: (...MISMATCH: MismatchArgs<Extends<Actual, void>, B>) => true
   toBeSymbol: (...MISMATCH: MismatchArgs<Extends<Actual, symbol>, B>) => true
   toBeNull: (...MISMATCH: MismatchArgs<Extends<Actual, null>, B>) => true
   toBeUndefined: (...MISMATCH: MismatchArgs<Extends<Actual, undefined>, B>) => true
@@ -164,6 +165,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(actual?: Actual): ExpectType
     toBeString: fn,
     toBeNumber: fn,
     toBeBoolean: fn,
+    toBeVoid: fn,
     toBeSymbol: fn,
     toBeNull: fn,
     toBeUndefined: fn,


### PR DESCRIPTION
Small PR that adds a `toBeVoid()`, e.g.:

```ts
expectTypeOf(someFunction).returns.toBeVoid()
```
