### PR TITLE
feat(expect-type): add `guards` & `asserts` getters

### DIFF
--- a/common/changes/expect-type/main_pr-231.json
+++ b/common/changes/expect-type/main_pr-231.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "feat(expect-type): add guardedType getter (#231) - @GerkinDev",
+      "type": "minor",
+      "packageName": "expect-type"
+    }
+  ],
+  "packageName": "expect-type",
+  "email": "GerkinDev@users.noreply.github.com"
+}

--- a/common/changes/expect-type/main_pr-231.json
+++ b/common/changes/expect-type/main_pr-231.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "feat(expect-type): add guardedType getter (#231) - @GerkinDev",
+      "comment": "feat(expect-type): add `guards` & `asserts` getters (#231) - @GerkinDev",
       "type": "minor",
       "packageName": "expect-type"
     }

--- a/packages/expect-type/readme.md
+++ b/packages/expect-type/readme.md
@@ -284,8 +284,8 @@ const assertNumber = (v: any): asserts v is number => {
 }
 expectTypeOf(assertNumber).asserts.toBeNumber()
 
-const isError = (v: any): v is string => typeof v === 'string'
-expectTypeOf(isError).guards.toBeString()
+const isString = (v: any): v is string => typeof v === 'string'
+expectTypeOf(isString).guards.toBeString()
 ```
 
 Assert on constructor parameters:

--- a/packages/expect-type/readme.md
+++ b/packages/expect-type/readme.md
@@ -274,6 +274,20 @@ const twoArgFunc = (a: number, b: string) => ({a, b})
 expectTypeOf(twoArgFunc).parameters.toEqualTypeOf<[number, string]>()
 ```
 
+You can also check type guards & type assertions:
+
+```typescript
+const assertNumber = (v: any): asserts v is number => {
+  if (typeof v !== 'number') {
+    throw new TypeError('Nope !')
+  }
+}
+expectTypeOf(assertNumber).asserts.toBeNumber()
+
+const isError = (v: any): v is string => typeof v === 'string'
+expectTypeOf(isError).guards.toBeString()
+```
+
 Assert on constructor parameters:
 
 ```typescript

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -191,8 +191,8 @@ test('You can also check type guards & type assertions', () => {
   }
   expectTypeOf(assertNumber).asserts.toBeNumber()
 
-  const isError = (v: any): v is string => typeof v === 'string'
-  expectTypeOf(isError).guards.toBeString()
+  const isString = (v: any): v is string => typeof v === 'string'
+  expectTypeOf(isString).guards.toBeString()
 })
 
 test('Assert on constructor parameters', () => {

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -183,6 +183,18 @@ test('More examples of ways to work with functions - parameters using `.paramete
   expectTypeOf(twoArgFunc).parameters.toEqualTypeOf<[number, string]>()
 })
 
+test('You can also check type guards & type assertions', () => {
+  const assertNumber = (v: any): asserts v is number => {
+    if (typeof v !== 'number') {
+      throw new TypeError('Nope !')
+    }
+  }
+  expectTypeOf(assertNumber).asserts.toBeNumber()
+
+  const isError = (v: any): v is string => typeof v === 'string'
+  expectTypeOf(isError).guards.toBeString()
+})
+
 test('Assert on constructor parameters', () => {
   expectTypeOf(Date).toBeConstructibleWith('1970')
   expectTypeOf(Date).toBeConstructibleWith(0)

--- a/packages/expect-type/src/__tests__/types.test.ts
+++ b/packages/expect-type/src/__tests__/types.test.ts
@@ -83,6 +83,13 @@ test('constructor params', () => {
   expectTypeOf<a.ConstructorParams<typeof Date>>().toEqualTypeOf<[] | [string | number | Date]>()
 })
 
+test('guarded type', () => {
+    expectTypeOf<(v: any) => v is string>().guardedType.toEqualTypeOf<string>();
+    expectTypeOf<(v: any) => asserts v is number>().guardedType.toEqualTypeOf<number>();
+    // @ts-expect-error
+    expectTypeOf<(v: any) => boolean>().guardedType.toBeNever();
+})
+
 test('parity with IsExact from conditional-type-checks', () => {
   // lifted from https://github.com/dsherret/conditional-type-checks/blob/01215056e8b97a28c5b0311b42ed48c70c8723fe/tests.ts#L18-L63
 

--- a/packages/expect-type/src/__tests__/types.test.ts
+++ b/packages/expect-type/src/__tests__/types.test.ts
@@ -83,11 +83,13 @@ test('constructor params', () => {
   expectTypeOf<a.ConstructorParams<typeof Date>>().toEqualTypeOf<[] | [string | number | Date]>()
 })
 
-test('guarded type', () => {
-    expectTypeOf<(v: any) => v is string>().guardedType.toEqualTypeOf<string>();
-    expectTypeOf<(v: any) => asserts v is number>().guardedType.toEqualTypeOf<number>();
-    // @ts-expect-error
-    expectTypeOf<(v: any) => boolean>().guardedType.toBeNever();
+test('guarded & asserted types', () => {
+  expectTypeOf<(v: any) => v is string>().guards.toBeString()
+  expectTypeOf<(v: any) => asserts v is number>().asserts.toBeNumber()
+  // @ts-expect-error
+  expectTypeOf<(v: any) => boolean>().guards.toBeAny()
+  // @ts-expect-error
+  expectTypeOf<(v: any) => boolean>().asserts.toBeAny()
 })
 
 test('parity with IsExact from conditional-type-checks', () => {

--- a/packages/expect-type/src/index.ts
+++ b/packages/expect-type/src/index.ts
@@ -63,7 +63,6 @@ type ReadonlyEquivalent<X, Y> = Extends<
 
 export type Extends<L, R> = IsNever<L> extends true ? IsNever<R> : L extends R ? true : false
 export type StrictExtends<L, R> = Extends<DeepBrand<L>, DeepBrand<R>>
-export type GuardedType<T> = ((v: any, ...args: any[]) => v is T) | ((v: any, ...args: any[]) => asserts v is T);
 
 export type Equal<Left, Right> = And<[StrictExtends<Left, Right>, StrictExtends<Right, Left>]>
 
@@ -114,12 +113,15 @@ export interface ExpectTypeOf<Actual, B extends boolean> {
   returns: Actual extends (...args: any[]) => infer R ? ExpectTypeOf<R, B> : never
   resolves: Actual extends PromiseLike<infer R> ? ExpectTypeOf<R, B> : never
   items: Actual extends ArrayLike<infer R> ? ExpectTypeOf<R, B> : never
-  guardedType: Actual extends GuardedType<infer R> ?
-    // Guard methods `(v: any) => asserts v is T` does not actually defines a return type. Thus, any function taking 1 argument matches the signature before.
-    // In case the inferred assertion type `R` could not be determined (so, `unknown`), consider the function as a non-guard, and return a `never` type.
-    // See https://github.com/microsoft/TypeScript/issues/34636
-    unknown extends R ? never :
-    ExpectTypeOf<R, B> : never
+  guards: Actual extends (v: any, ...args: any[]) => v is infer T ? ExpectTypeOf<T, B> : never
+  asserts: Actual extends (v: any, ...args: any[]) => asserts v is infer T
+    ? // Guard methods `(v: any) => asserts v is T` does not actually defines a return type. Thus, any function taking 1 argument matches the signature before.
+      // In case the inferred assertion type `R` could not be determined (so, `unknown`), consider the function as a non-guard, and return a `never` type.
+      // See https://github.com/microsoft/TypeScript/issues/34636
+      unknown extends T
+      ? never
+      : ExpectTypeOf<T, B>
+    : never
   not: ExpectTypeOf<Actual, Not<B>>
 }
 const fn: any = () => true
@@ -160,7 +162,8 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(actual?: Actual): ExpectType
     'items',
     'constructorParameters',
     'instance',
-    'guardedType',
+    'guards',
+    'asserts',
   ] as const
   type Keys = keyof ExpectTypeOf<any, any>
 


### PR DESCRIPTION
Test the type asserted or guarded by the subject function.

<!-- Every pull request which changes one of the packages in this monorepo needs to be accompanied by a rush changefile. The change text needs to consist of the PR title and number. There's a CI job that checks this for you, and prints a runnable command for generating the file. After you open the PR, watch out for the "create change files" workflow - that will have instructions for creating the changefile. -->
