### PR TITLE
fix: make strict combinator check for missing values

### DIFF
--- a/common/changes/io-ts-extra/main_pr-240.json
+++ b/common/changes/io-ts-extra/main_pr-240.json
@@ -1,8 +1,8 @@
 {
   "changes": [
     {
-      "comment": "Make strict combinator check for missing values (#240) - @jpdenford",
-      "type": "minor",
+      "comment": "fix: make strict combinator check for missing values (#240) - @jpdenford",
+      "type": "patch",
       "packageName": "io-ts-extra"
     }
   ],

--- a/common/changes/io-ts-extra/main_pr-240.json
+++ b/common/changes/io-ts-extra/main_pr-240.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Make strict combinator check for missing values (#240) - @jpdenford",
+      "type": "minor",
+      "packageName": "io-ts-extra"
+    }
+  ],
+  "packageName": "io-ts-extra",
+  "email": "jpdenford@users.noreply.github.com"
+}

--- a/packages/io-ts-extra/src/__tests__/combinators.test.ts
+++ b/packages/io-ts-extra/src/__tests__/combinators.test.ts
@@ -102,6 +102,7 @@ test('strict', () => {
   const Person = strict({name: t.string, age: t.number})
 
   expectRight(Person.decode({name: 'Alice', age: 30}))
+  expectLeft(Person.decode({name: 'Alice'}))
   expectLeft(Person.decode({name: 'Bob', age: 30, unexpectedProp: 'abc'}))
   expectRight(Person.decode({name: 'Bob', age: 30, unexpectedProp: undefined}))
 

--- a/packages/io-ts-extra/src/combinators.ts
+++ b/packages/io-ts-extra/src/combinators.ts
@@ -168,7 +168,7 @@ export const strict = <P extends Props>(props: P, name?: string) => {
       }
       const stricterProps = Object.keys(val).reduce<Props>(
         (acc, next) => ({...acc, [next]: props[next] || t.undefined}),
-        {}
+        props
       )
       return sparseType(stricterProps as typeof props).validate(val, ctx)
     },


### PR DESCRIPTION
Ensure strict combinator fails when required properties are missing from input object.