### PR TITLE
fix mapper does not support nested mapped types

### DIFF
--- a/packages/io-ts-extra/src/__tests__/mapper.test.ts
+++ b/packages/io-ts-extra/src/__tests__/mapper.test.ts
@@ -51,6 +51,35 @@ describe('mapper', () => {
     expect(BoolToStringArray.encode(['f', 'a', 'l', 's', 'e'])).toEqual(false)
   })
 
+  it('map decodes nested mapped types', () => {
+    const Bool_Number = mapper(
+      t.boolean,
+      t.number,
+      b => (b ? 1 : 0),
+      n => n === 1
+    )
+
+    const Bool_Number_String = mapper(t.string, Bool_Number, JSON.parse, JSON.stringify)
+
+    expect(Bool_Number_String.decode('true')).toMatchInlineSnapshot(`
+      _tag: Right
+      right: 1
+    `)
+  })
+
+  it('unmap encodes nested mapped types', () => {
+    const Bool_Number = mapper(
+      t.boolean,
+      t.number,
+      b => (b ? 1 : 0),
+      n => n === 1
+    )
+
+    const Bool_Number_String = mapper(t.string, Bool_Number, JSON.parse, JSON.stringify)
+
+    expect(Bool_Number_String.encode(1)).toEqual('true')
+  })
+
   it('throws helpfully when unmap not implemented', () => {
     const BoolToStringArray = mapper(t.boolean, t.array(t.string), b => b.toString().split(''))
     expect(() => (BoolToStringArray as any).encode(['f', 'a', 'l', 's', 'e'])).toThrowErrorMatchingInlineSnapshot(`


### PR DESCRIPTION
Fixes typings and encoder functionality to support creating mapped types that include nested mapped types, as per https://github.com/mmkal/ts/issues/246

<!-- Every pull request which changes one of the packages in this monorepo needs to be accompanied by a rush changefile. The change text needs to consist of the PR title and number. There's a CI job that checks this for you, and prints a runnable command for generating the file. After you open the PR, watch out for the "create change files" workflow - that will have instructions for creating the changefile. -->
