### PR TITLE
fix(expect-type): check  `this` param in functions

### DIFF
--- a/common/changes/expect-type/expect-type-this-param_pr-252.json
+++ b/common/changes/expect-type/expect-type-this-param_pr-252.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix(expect-type): check  `this` param in functions (#252) - @papb",
+      "type": "patch",
+      "packageName": "expect-type"
+    }
+  ],
+  "packageName": "expect-type",
+  "email": "papb@users.noreply.github.com"
+}

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -216,7 +216,7 @@ test('Of course, `.toEqualTypeOf` also distinguishes the `this` argument between
   type UnknownThisParam = (this: unknown, a: number) => void
   type AnyThisParam = (this: any, a: number) => void
 
-	// `NoThisParam` and `UnknownThisParam` are the only ones that should be considered equivalent.
+  // `NoThisParam` and `UnknownThisParam` are the only ones that should be considered equivalent.
 
   expectTypeOf<NoThisParam>().toEqualTypeOf<NoThisParam>();
   expectTypeOf<NoThisParam>().not.toEqualTypeOf<DateThisParam>();

--- a/packages/expect-type/src/__tests__/index.test.ts
+++ b/packages/expect-type/src/__tests__/index.test.ts
@@ -195,6 +195,60 @@ test('You can also check type guards & type assertions', () => {
   expectTypeOf(isString).guards.toBeString()
 })
 
+test('You can also check the `this` argument of functions using `.thisParam', () => {
+  type NoThisParam = (a: number) => void
+  type DateThisParam = (this: Date, a: number) => void
+  type UndefinedThisParam = (this: undefined, a: number) => void
+  type UnknownThisParam = (this: unknown, a: number) => void
+  type AnyThisParam = (this: any, a: number) => void
+
+  expectTypeOf<NoThisParam>().thisParam.toBeUnknown();
+  expectTypeOf<DateThisParam>().thisParam.toEqualTypeOf<Date>();
+  expectTypeOf<UndefinedThisParam>().thisParam.toBeUndefined();
+  expectTypeOf<UnknownThisParam>().thisParam.toBeUnknown();
+  expectTypeOf<AnyThisParam>().thisParam.toBeAny();
+})
+
+test('Of course, `.toEqualTypeOf` also distinguishes the `this` argument between functions', () => {
+  type NoThisParam = (a: number) => void
+  type DateThisParam = (this: Date, a: number) => void
+  type UndefinedThisParam = (this: undefined, a: number) => void
+  type UnknownThisParam = (this: unknown, a: number) => void
+  type AnyThisParam = (this: any, a: number) => void
+
+	// `NoThisParam` and `UnknownThisParam` are the only ones that should be considered equivalent.
+
+  expectTypeOf<NoThisParam>().toEqualTypeOf<NoThisParam>();
+  expectTypeOf<NoThisParam>().not.toEqualTypeOf<DateThisParam>();
+  expectTypeOf<NoThisParam>().not.toEqualTypeOf<UndefinedThisParam>();
+  expectTypeOf<NoThisParam>().toEqualTypeOf<UnknownThisParam>();
+  expectTypeOf<NoThisParam>().not.toEqualTypeOf<AnyThisParam>();
+
+  expectTypeOf<DateThisParam>().not.toEqualTypeOf<NoThisParam>();
+  expectTypeOf<DateThisParam>().toEqualTypeOf<DateThisParam>();
+  expectTypeOf<DateThisParam>().not.toEqualTypeOf<UndefinedThisParam>();
+  expectTypeOf<DateThisParam>().not.toEqualTypeOf<UnknownThisParam>();
+  expectTypeOf<DateThisParam>().not.toEqualTypeOf<AnyThisParam>();
+
+  expectTypeOf<UndefinedThisParam>().not.toEqualTypeOf<NoThisParam>();
+  expectTypeOf<UndefinedThisParam>().not.toEqualTypeOf<DateThisParam>();
+  expectTypeOf<UndefinedThisParam>().toEqualTypeOf<UndefinedThisParam>();
+  expectTypeOf<UndefinedThisParam>().not.toEqualTypeOf<UnknownThisParam>();
+  expectTypeOf<UndefinedThisParam>().not.toEqualTypeOf<AnyThisParam>();
+
+  expectTypeOf<UnknownThisParam>().toEqualTypeOf<NoThisParam>();
+  expectTypeOf<UnknownThisParam>().not.toEqualTypeOf<DateThisParam>();
+  expectTypeOf<UnknownThisParam>().not.toEqualTypeOf<UndefinedThisParam>();
+  expectTypeOf<UnknownThisParam>().toEqualTypeOf<UnknownThisParam>();
+  expectTypeOf<UnknownThisParam>().not.toEqualTypeOf<AnyThisParam>();
+
+  expectTypeOf<AnyThisParam>().not.toEqualTypeOf<NoThisParam>();
+  expectTypeOf<AnyThisParam>().not.toEqualTypeOf<DateThisParam>();
+  expectTypeOf<AnyThisParam>().not.toEqualTypeOf<UndefinedThisParam>();
+  expectTypeOf<AnyThisParam>().not.toEqualTypeOf<UnknownThisParam>();
+  expectTypeOf<AnyThisParam>().toEqualTypeOf<AnyThisParam>();
+})
+
 test('Assert on constructor parameters', () => {
   expectTypeOf(Date).toBeConstructibleWith('1970')
   expectTypeOf(Date).toBeConstructibleWith(0)

--- a/packages/expect-type/src/index.ts
+++ b/packages/expect-type/src/index.ts
@@ -38,6 +38,7 @@ export type DeepBrand<T> = Or<[IsNever<T>, IsAny<T>, IsUnknown<T>]> extends true
       params: DeepBrand<P>
       return: DeepBrand<R>
       constructorParams: DeepBrand<ConstructorParams<T>>
+      thisParam: DeepBrand<ThisParameterType<T>>
     }
   : {
       type: 'object'
@@ -119,6 +120,7 @@ export interface ExpectTypeOf<Actual, B extends boolean> {
   parameter: <K extends keyof Params<Actual>>(number: K) => ExpectTypeOf<Params<Actual>[K], B>
   parameters: ExpectTypeOf<Params<Actual>, B>
   constructorParameters: ExpectTypeOf<ConstructorParams<Actual>, B>
+  thisParam: ExpectTypeOf<ThisParameterType<Actual>, B>
   instance: Actual extends new (...args: any[]) => infer I ? ExpectTypeOf<I, B> : never
   returns: Actual extends (...args: any[]) => infer R ? ExpectTypeOf<R, B> : never
   resolves: Actual extends PromiseLike<infer R> ? ExpectTypeOf<R, B> : never
@@ -171,6 +173,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(actual?: Actual): ExpectType
     'not',
     'items',
     'constructorParameters',
+    'thisParam',
     'instance',
     'guards',
     'asserts',


### PR DESCRIPTION
<!-- Every pull request which changes one of the packages in this monorepo needs to be accompanied by a rush changefile. The change text needs to consist of the PR title and number. There's a CI job that checks this for you, and prints a runnable command for generating the file. After you open the PR, watch out for the "create change files" workflow - that will have instructions for creating the changefile. -->

Closes mmkal/expect-type#7

I also added `.thisParam`. So this PR is a mix of fix and feat. Should it have been two separate PRs?
