### PR TITLE
Add support for asset imports

### DIFF
--- a/common/changes/eslint-plugin-codegen/patch-1_pr-258.json
+++ b/common/changes/eslint-plugin-codegen/patch-1_pr-258.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add support for asset imports (#258) - @yenbekbay",
+      "type": "minor",
+      "packageName": "eslint-plugin-codegen"
+    }
+  ],
+  "packageName": "eslint-plugin-codegen",
+  "email": "yenbekbay@users.noreply.github.com"
+}

--- a/packages/eslint-plugin-codegen/src/presets/__tests__/barrel.test.ts
+++ b/packages/eslint-plugin-codegen/src/presets/__tests__/barrel.test.ts
@@ -309,12 +309,12 @@ test(`supports asset imports`, () => {
       options: {include: '*.{jpg,png}', import: 'default'},
     })
   ).toMatchInlineSnapshot(`
-      "import a from './a.jpg'
-      import b from './b.png'
+      "import aJpg from './a.jpg'
+      import bPng from './b.png'
 
       export {
-       a,
-       b
+       aJpg,
+       bPng
       }
       "
     `)

--- a/packages/eslint-plugin-codegen/src/presets/__tests__/barrel.test.ts
+++ b/packages/eslint-plugin-codegen/src/presets/__tests__/barrel.test.ts
@@ -296,3 +296,26 @@ test(`index files are sensibly-named`, () => {
     "
   `)
 })
+
+test(`supports asset imports`, () => {
+  Object.assign(mockFs, {
+    'a.jpg': '',
+    'b.png': '',
+  })
+
+  expect(
+    preset.barrel({
+      meta: {filename: 'index.ts', existingContent: ''},
+      options: {include: '*.{jpg,png}', import: 'default'},
+    })
+  ).toMatchInlineSnapshot(`
+      "import a from './a.jpg'
+      import b from './b.png'
+
+      export {
+       a,
+       b
+      }
+      "
+    `)
+})

--- a/packages/eslint-plugin-codegen/src/presets/barrel.ts
+++ b/packages/eslint-plugin-codegen/src/presets/barrel.ts
@@ -46,8 +46,7 @@ export const barrel: Preset<{
     .sync(pattern, {cwd, ignore: opts.exclude})
     .filter(f => path.resolve(cwd, f) !== path.resolve(meta.filename))
     .map(f => `./${f}`.replace(/(\.\/)+\./g, '.'))
-    .filter(file => ['.js', '.mjs', '.ts', '.tsx'].includes(path.extname(file)))
-    .map(f => f.replace(/\.\w+$/, ''))
+    .map(f => ['.js', '.mjs', '.ts', '.tsx'].includes(path.extname(file)) ? f.replace(/\.\w+$/, '') : f)
 
   const expectedContent = match(opts.import)
     .case(undefined, () => {

--- a/packages/eslint-plugin-codegen/src/presets/barrel.ts
+++ b/packages/eslint-plugin-codegen/src/presets/barrel.ts
@@ -46,7 +46,7 @@ export const barrel: Preset<{
     .sync(pattern, {cwd, ignore: opts.exclude})
     .filter(f => path.resolve(cwd, f) !== path.resolve(meta.filename))
     .map(f => `./${f}`.replace(/(\.\/)+\./g, '.'))
-    .map(f => ['.js', '.mjs', '.ts', '.tsx'].includes(path.extname(file)) ? f.replace(/\.\w+$/, '') : f)
+    .map(f => ['.js', '.mjs', '.ts', '.tsx'].includes(path.extname(f)) ? f.replace(/\.\w+$/, '') : f)
 
   const expectedContent = match(opts.import)
     .case(undefined, () => {


### PR DESCRIPTION
Bundlers such as Webpack and esbuild enable importing asset/external files. It would be nice to have barrels be auto-generated for those files as well.